### PR TITLE
Use existing channelDegrees for injector schedules

### DIFF
--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -465,7 +465,7 @@ void initialiseAll(void)
     switch (configPage2.nCylinders) {
     case 1:
         ignitionSchedule1.channelDegrees = 0;
-        channel1InjDegrees = 0;
+        fuelSchedule1.channelDegrees = 0;
         maxIgnOutputs = 1;
 
         //Sequential ignition works identically on a 1 cylinder whether it's odd or even fire. 
@@ -484,13 +484,13 @@ void initialiseAll(void)
         if(configPage10.stagingEnabled == true)
         {
           channel3InjEnabled = true;
-          channel3InjDegrees = channel1InjDegrees;
+          fuelSchedule3.channelDegrees = fuelSchedule1.channelDegrees;
         }
         break;
 
     case 2:
         ignitionSchedule1.channelDegrees = 0;
-        channel1InjDegrees = 0;
+        fuelSchedule1.channelDegrees = 0;
         maxIgnOutputs = 2;
         if (configPage2.engineType == EVEN_FIRE ) { ignitionSchedule2.channelDegrees = 180; }
         else { ignitionSchedule2.channelDegrees = configPage2.oddfire2; }
@@ -505,13 +505,13 @@ void initialiseAll(void)
           req_fuel_uS = req_fuel_uS * 2;
         }
         //The below are true regardless of whether this is running sequential or not
-        if (configPage2.engineType == EVEN_FIRE ) { channel2InjDegrees = 180; }
-        else { channel2InjDegrees = configPage2.oddfire2; }
+        if (configPage2.engineType == EVEN_FIRE ) { fuelSchedule2.channelDegrees = 180; }
+        else { fuelSchedule2.channelDegrees = configPage2.oddfire2; }
         if (!configPage2.injTiming) 
         { 
           //For simultaneous, all squirts happen at the same time
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 0; 
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 0; 
         }
 
         channel1InjEnabled = true;
@@ -523,8 +523,8 @@ void initialiseAll(void)
           channel3InjEnabled = true;
           channel4InjEnabled = true;
 
-          channel3InjDegrees = channel1InjDegrees;
-          channel4InjDegrees = channel2InjDegrees;
+          fuelSchedule3.channelDegrees = fuelSchedule1.channelDegrees;
+          fuelSchedule4.channelDegrees = fuelSchedule2.channelDegrees;
         }
 
         break;
@@ -557,30 +557,30 @@ void initialiseAll(void)
         //For alternating injection, the squirt occurs at different times for each channel
         if( (configPage2.injLayout == INJ_SEMISEQUENTIAL) || (configPage2.injLayout == INJ_PAIRED) || (configPage2.strokes == TWO_STROKE) )
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 120;
-          channel3InjDegrees = 240;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 120;
+          fuelSchedule3.channelDegrees = 240;
 
           //Adjust the injection angles based on the number of squirts
           if (currentStatus.nSquirts > 2)
           {
-            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
-            channel3InjDegrees = (channel3InjDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule2.channelDegrees = (fuelSchedule2.channelDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule3.channelDegrees = (fuelSchedule3.channelDegrees * 2) / currentStatus.nSquirts;
           }
 
           if (!configPage2.injTiming) 
           { 
             //For simultaneous, all squirts happen at the same time
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 0;
-            channel3InjDegrees = 0; 
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 0;
+            fuelSchedule3.channelDegrees = 0; 
           } 
         }
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 240;
-          channel3InjDegrees = 480;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 240;
+          fuelSchedule3.channelDegrees = 480;
           CRANK_ANGLE_MAX_INJ = 720;
           currentStatus.nSquirts = 1;
           req_fuel_uS = req_fuel_uS * 2;
@@ -588,9 +588,9 @@ void initialiseAll(void)
         else
         {
           //Should never happen, but default values
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 120;
-          channel3InjDegrees = 240;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 120;
+          fuelSchedule3.channelDegrees = 240;
         }
 
         channel1InjEnabled = true;
@@ -599,7 +599,7 @@ void initialiseAll(void)
         break;
     case 4:
         ignitionSchedule1.channelDegrees = 0;
-        channel1InjDegrees = 0;
+        fuelSchedule1.channelDegrees = 0;
         maxIgnOutputs = 2; //Default value for 4 cylinder, may be changed below
         if (configPage2.engineType == EVEN_FIRE )
         {
@@ -634,26 +634,26 @@ void initialiseAll(void)
         //For alternating injection, the squirt occurs at different times for each channel
         if( (configPage2.injLayout == INJ_SEMISEQUENTIAL) || (configPage2.injLayout == INJ_PAIRED) || (configPage2.strokes == TWO_STROKE) )
         {
-          channel2InjDegrees = 180;
+          fuelSchedule2.channelDegrees = 180;
 
           if (!configPage2.injTiming) 
           { 
             //For simultaneous, all squirts happen at the same time
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 0; 
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 0; 
           }
           else if (currentStatus.nSquirts > 2)
           {
             //Adjust the injection angles based on the number of squirts
-            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule2.channelDegrees = (fuelSchedule2.channelDegrees * 2) / currentStatus.nSquirts;
           }
           else { } //Do nothing, default values are correct
         }
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
-          channel2InjDegrees = 180;
-          channel3InjDegrees = 360;
-          channel4InjDegrees = 540;
+          fuelSchedule2.channelDegrees = 180;
+          fuelSchedule3.channelDegrees = 360;
+          fuelSchedule4.channelDegrees = 540;
 
           channel3InjEnabled = true;
           channel4InjEnabled = true;
@@ -679,8 +679,8 @@ void initialiseAll(void)
           channel3InjEnabled = true;
           channel4InjEnabled = true;
 
-          channel3InjDegrees = channel1InjDegrees;
-          channel4InjDegrees = channel2InjDegrees;
+          fuelSchedule3.channelDegrees = fuelSchedule1.channelDegrees;
+          fuelSchedule4.channelDegrees = fuelSchedule2.channelDegrees;
         }
 
         channel1InjEnabled = true;
@@ -710,19 +710,23 @@ void initialiseAll(void)
           if (!configPage2.injTiming) 
           { 
             //For simultaneous, all squirts happen at the same time
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 0;
-            channel3InjDegrees = 0;
-            channel4InjDegrees = 0;
-            channel5InjDegrees = 0; 
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 0;
+            fuelSchedule3.channelDegrees = 0;
+            fuelSchedule4.channelDegrees = 0;
+            #if INJ_CHANNELS >= 5
+            fuelSchedule5.channelDegrees = 0;
+            #endif
           }
           else
           {
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 72;
-            channel3InjDegrees = 144;
-            channel4InjDegrees = 216;
-            channel5InjDegrees = 288;
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 72;
+            fuelSchedule3.channelDegrees = 144;
+            fuelSchedule4.channelDegrees = 216;
+            #if INJ_CHANNELS >= 5
+            fuelSchedule5.channelDegrees = 288;
+            #endif
 
             //Divide by currentStatus.nSquirts ?
           }
@@ -730,11 +734,11 @@ void initialiseAll(void)
     #if INJ_CHANNELS >= 5
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 144;
-          channel3InjDegrees = 288;
-          channel4InjDegrees = 432;
-          channel5InjDegrees = 576;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 144;
+          fuelSchedule3.channelDegrees = 288;
+          fuelSchedule4.channelDegrees = 432;
+          fuelSchedule5.channelDegrees = 576;
 
           channel5InjEnabled = true;
 
@@ -769,33 +773,33 @@ void initialiseAll(void)
         //For alternating injection, the squirt occurs at different times for each channel
         if( (configPage2.injLayout == INJ_SEMISEQUENTIAL) || (configPage2.injLayout == INJ_PAIRED) )
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 120;
-          channel3InjDegrees = 240;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 120;
+          fuelSchedule3.channelDegrees = 240;
           if (!configPage2.injTiming)
           {
             //For simultaneous, all squirts happen at the same time
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 0;
-            channel3InjDegrees = 0;
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 0;
+            fuelSchedule3.channelDegrees = 0;
           }
           else if (currentStatus.nSquirts > 2)
           {
             //Adjust the injection angles based on the number of squirts
-            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
-            channel3InjDegrees = (channel3InjDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule2.channelDegrees = (fuelSchedule2.channelDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule3.channelDegrees = (fuelSchedule3.channelDegrees * 2) / currentStatus.nSquirts;
           }
         }
 
     #if INJ_CHANNELS >= 6
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 120;
-          channel3InjDegrees = 240;
-          channel4InjDegrees = 360;
-          channel5InjDegrees = 480;
-          channel6InjDegrees = 600;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 120;
+          fuelSchedule3.channelDegrees = 240;
+          fuelSchedule4.channelDegrees = 360;
+          fuelSchedule5.channelDegrees = 480;
+          fuelSchedule6.channelDegrees = 600;
 
           channel4InjEnabled = true;
           channel5InjEnabled = true;
@@ -841,39 +845,39 @@ void initialiseAll(void)
         //For alternating injection, the squirt occurs at different times for each channel
         if( (configPage2.injLayout == INJ_SEMISEQUENTIAL) || (configPage2.injLayout == INJ_PAIRED) )
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 90;
-          channel3InjDegrees = 180;
-          channel4InjDegrees = 270;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 90;
+          fuelSchedule3.channelDegrees = 180;
+          fuelSchedule4.channelDegrees = 270;
 
           if (!configPage2.injTiming)
           {
             //For simultaneous, all squirts happen at the same time
-            channel1InjDegrees = 0;
-            channel2InjDegrees = 0;
-            channel3InjDegrees = 0;
-            channel4InjDegrees = 0;
+            fuelSchedule1.channelDegrees = 0;
+            fuelSchedule2.channelDegrees = 0;
+            fuelSchedule3.channelDegrees = 0;
+            fuelSchedule4.channelDegrees = 0;
           }
           else if (currentStatus.nSquirts > 2)
           {
             //Adjust the injection angles based on the number of squirts
-            channel2InjDegrees = (channel2InjDegrees * 2) / currentStatus.nSquirts;
-            channel3InjDegrees = (channel3InjDegrees * 2) / currentStatus.nSquirts;
-            channel4InjDegrees = (channel4InjDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule2.channelDegrees = (fuelSchedule2.channelDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule3.channelDegrees = (fuelSchedule3.channelDegrees * 2) / currentStatus.nSquirts;
+            fuelSchedule4.channelDegrees = (fuelSchedule4.channelDegrees * 2) / currentStatus.nSquirts;
           }
         }
 
     #if INJ_CHANNELS >= 8
         else if (configPage2.injLayout == INJ_SEQUENTIAL)
         {
-          channel1InjDegrees = 0;
-          channel2InjDegrees = 90;
-          channel3InjDegrees = 180;
-          channel4InjDegrees = 270;
-          channel5InjDegrees = 360;
-          channel6InjDegrees = 450;
-          channel7InjDegrees = 540;
-          channel8InjDegrees = 630;
+          fuelSchedule1.channelDegrees = 0;
+          fuelSchedule2.channelDegrees = 90;
+          fuelSchedule3.channelDegrees = 180;
+          fuelSchedule4.channelDegrees = 270;
+          fuelSchedule5.channelDegrees = 360;
+          fuelSchedule6.channelDegrees = 450;
+          fuelSchedule7.channelDegrees = 540;
+          fuelSchedule8.channelDegrees = 630;
 
           channel5InjEnabled = true;
           channel6InjEnabled = true;
@@ -892,8 +896,8 @@ void initialiseAll(void)
         channel4InjEnabled = true;
         break;
     default: //Handle this better!!!
-        channel1InjDegrees = 0;
-        channel2InjDegrees = 180;
+        fuelSchedule1.channelDegrees = 0;
+        fuelSchedule2.channelDegrees = 180;
         break;
     }
 

--- a/speeduino/speeduino.h
+++ b/speeduino/speeduino.h
@@ -35,15 +35,6 @@ extern byte curRollingCut; /**< Rolling rev limiter, current ignition channel be
 extern byte rollingCutCounter; /**< how many times (revolutions) the ignition has been cut in a row */
 extern uint32_t rollingCutLastRev; /**< Tracks whether we're on the same or a different rev for the rolling cut */
 
-extern int channel1InjDegrees; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-extern int channel2InjDegrees; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-extern int channel3InjDegrees; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-extern int channel4InjDegrees; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-extern int channel5InjDegrees; /**< The number of crank degrees until cylinder 5 is at TDC */
-extern int channel6InjDegrees; /**< The number of crank degrees until cylinder 6 is at TDC */
-extern int channel7InjDegrees; /**< The number of crank degrees until cylinder 7 is at TDC */
-extern int channel8InjDegrees; /**< The number of crank degrees until cylinder 8 is at TDC */
-
 /** @name Staging
  * These values are a percentage of the total (Combined) req_fuel value that would be required for each injector channel to deliver that much fuel.   
  * 

--- a/speeduino/speeduino.ino
+++ b/speeduino/speeduino.ino
@@ -46,16 +46,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include RTC_LIB_H //Defined in each boards .h file
 #include BOARD_H //Note that this is not a real file, it is defined in globals.h. 
 
-
-int channel1InjDegrees = 0; /**< The number of crank degrees until cylinder 1 is at TDC (This is obviously 0 for virtually ALL engines, but there's some weird ones) */
-int channel2InjDegrees = 0; /**< The number of crank degrees until cylinder 2 (and 5/6/7/8) is at TDC */
-int channel3InjDegrees = 0; /**< The number of crank degrees until cylinder 3 (and 5/6/7/8) is at TDC */
-int channel4InjDegrees = 0; /**< The number of crank degrees until cylinder 4 (and 5/6/7/8) is at TDC */
-int channel5InjDegrees = 0; /**< The number of crank degrees until cylinder 5 is at TDC */
-int channel6InjDegrees = 0; /**< The number of crank degrees until cylinder 6 is at TDC */
-int channel7InjDegrees = 0; /**< The number of crank degrees until cylinder 7 is at TDC */
-int channel8InjDegrees = 0; /**< The number of crank degrees until cylinder 8 is at TDC */
-
 uint16_t req_fuel_uS = 0; /**< The required fuel variable (As calculated by TunerStudio) in uS */
 uint16_t inj_opentime_uS = 0;
 
@@ -588,7 +578,7 @@ void loop(void)
       //BEGIN INJECTION TIMING
       currentStatus.injAngle = table2D_getValue(&injectorAngleTable, currentStatus.RPMdiv100);
 
-      injector1EndAngle= calculateInjectorEndAngle(channel1InjDegrees);
+      injector1EndAngle= calculateInjectorEndAngle(fuelSchedule1.channelDegrees);
 
       //Repeat the above for each cylinder
       switch (configPage2.nCylinders)
@@ -598,12 +588,12 @@ void loop(void)
           //The only thing that needs to be done for single cylinder is to check for staging. 
           if( (configPage10.stagingEnabled == true) && (currentStatus.PW3 > 0) )
           {
-            injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
+            injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
           }
           break;
         //2 cylinders
         case 2:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
           
           if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
             {
@@ -612,7 +602,7 @@ void loop(void)
             }
           else if( (configPage10.stagingEnabled == true) && (currentStatus.PW3 > 0) )
           {
-            injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
+            injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
 
             injector4EndAngle = injector3EndAngle + (CRANK_ANGLE_MAX_INJ / 2); //Phase this either 180 or 360 degrees out from inj3 (In reality this will always be 180 as you can't have sequential and staged currently)
             if(injector4EndAngle > (uint16_t)CRANK_ANGLE_MAX_INJ) { injector4EndAngle -= CRANK_ANGLE_MAX_INJ; }
@@ -620,8 +610,8 @@ void loop(void)
           break;
         //3 cylinders
         case 3:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
-          injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
+          injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
           
           if ( (configPage2.injLayout == INJ_SEQUENTIAL) && (configPage6.fuelTrimEnabled > 0) )
             {
@@ -632,14 +622,14 @@ void loop(void)
           break;
         //4 cylinders
         case 4:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
 
           if((configPage2.injLayout == INJ_SEQUENTIAL) && currentStatus.hasSync)
           {
             if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
 
-            injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
-            injector4EndAngle= calculateInjectorEndAngle(channel4InjDegrees);
+            injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
+            injector4EndAngle= calculateInjectorEndAngle(fuelSchedule4.channelDegrees);
 
             if(configPage6.fuelTrimEnabled > 0)
             {
@@ -651,7 +641,7 @@ void loop(void)
           }
           else if( (configPage10.stagingEnabled == true) && (currentStatus.PW3 > 0) )
           {
-            injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
+            injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
 
             injector4EndAngle = injector3EndAngle + (CRANK_ANGLE_MAX_INJ / 2); //Phase this either 180 or 360 degrees out from inj3 (In reality this will always be 180 as you can't have sequential and staged currently)
             if(injector4EndAngle > (uint16_t)CRANK_ANGLE_MAX_INJ) { injector4EndAngle -= CRANK_ANGLE_MAX_INJ; }
@@ -663,26 +653,26 @@ void loop(void)
           break;
         //5 cylinders
         case 5:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
-          injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
-          injector4EndAngle= calculateInjectorEndAngle(channel4InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
+          injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
+          injector4EndAngle= calculateInjectorEndAngle(fuelSchedule4.channelDegrees);
           #if INJ_CHANNELS >= 5
-            injector5EndAngle= calculateInjectorEndAngle(channel5InjDegrees);
+            injector5EndAngle= calculateInjectorEndAngle(fuelSchedule5.channelDegrees);
           #endif
           break;
         //6 cylinders
         case 6:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
-          injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
+          injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
           
           #if INJ_CHANNELS >= 6
             if((configPage2.injLayout == INJ_SEQUENTIAL) && currentStatus.hasSync)
             {
             if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
 
-              injector4EndAngle= calculateInjectorEndAngle(channel4InjDegrees);
-              injector5EndAngle= calculateInjectorEndAngle(channel5InjDegrees);
-              injector6EndAngle= calculateInjectorEndAngle(channel6InjDegrees);
+              injector4EndAngle= calculateInjectorEndAngle(fuelSchedule4.channelDegrees);
+              injector5EndAngle= calculateInjectorEndAngle(fuelSchedule5.channelDegrees);
+              injector6EndAngle= calculateInjectorEndAngle(fuelSchedule6.channelDegrees);
 
               if(configPage6.fuelTrimEnabled > 0)
               {
@@ -702,18 +692,18 @@ void loop(void)
           break;
         //8 cylinders
         case 8:
-          injector2EndAngle= calculateInjectorEndAngle(channel2InjDegrees);
-          injector3EndAngle= calculateInjectorEndAngle(channel3InjDegrees);
-          injector4EndAngle= calculateInjectorEndAngle(channel4InjDegrees);
+          injector2EndAngle= calculateInjectorEndAngle(fuelSchedule2.channelDegrees);
+          injector3EndAngle= calculateInjectorEndAngle(fuelSchedule3.channelDegrees);
+          injector4EndAngle= calculateInjectorEndAngle(fuelSchedule4.channelDegrees);
 
           #if INJ_CHANNELS >= 8
             if((configPage2.injLayout == INJ_SEQUENTIAL) && currentStatus.hasSync)
             {
               if( CRANK_ANGLE_MAX_INJ != 720 ) { changeHalfToFullSync(); }
-              injector5EndAngle= calculateInjectorEndAngle(channel5InjDegrees);
-              injector6EndAngle= calculateInjectorEndAngle(channel6InjDegrees);
-              injector7EndAngle= calculateInjectorEndAngle(channel7InjDegrees);
-              injector8EndAngle= calculateInjectorEndAngle(channel8InjDegrees);
+              injector5EndAngle= calculateInjectorEndAngle(fuelSchedule5.channelDegrees);
+              injector6EndAngle= calculateInjectorEndAngle(fuelSchedule6.channelDegrees);
+              injector7EndAngle= calculateInjectorEndAngle(fuelSchedule7.channelDegrees);
+              injector8EndAngle= calculateInjectorEndAngle(fuelSchedule8.channelDegrees);
 
               if(configPage6.fuelTrimEnabled > 0)
               {


### PR DESCRIPTION
Saves 8 bytes of memory and 58 bytes of firmware. Loops/sec seem to be unaffected as expected. No obvious issues on the scope as expected.